### PR TITLE
[expense-approval_250319_jsm] userInfo 상태 접근 및 전달 방식 변경

### DIFF
--- a/src/components/page/Personnel/AttendanceApproval/AttendanceApprovalMain/AttendanceApprovalMain.tsx
+++ b/src/components/page/Personnel/AttendanceApproval/AttendanceApprovalMain/AttendanceApprovalMain.tsx
@@ -10,13 +10,12 @@ import { AttendanceApprovalModal } from "../AttendanceApprovalModal/AttendanceAp
 import { searchApi } from "../../../../../api/PersonnelApi/searchApi";
 import { AttendanceApproval } from "../../../../../api/api";
 import { IAttendance } from "../../../../../models/interface/personnel/attendance/IAttendance";
-
 interface IAttendanceListResponse {
     attendanceList: IAttendance[],
     attendanceRequestCnt: number
 }
 
-export const AttendanceApprovalMain = ({ loginUserType, loginUserEmpid }) => {
+export const AttendanceApprovalMain = () => {
     const [attendanceList, setAttendanceList] = useState<IAttendance[]>([]);
     const [attendanceRequestCnt, setAttendanceRequestCnt] = useState<number>(0);
     const [cPage, setCPage] = useState<number>(0);
@@ -85,7 +84,7 @@ export const AttendanceApprovalMain = ({ loginUserType, loginUserEmpid }) => {
             {
                 modal && (
                     <Portal>
-                        <AttendanceApprovalModal id={id} setId={setId} postSuccess={postSuccess} loginUserType={loginUserType} loginUserEmpid={loginUserEmpid} />
+                        <AttendanceApprovalModal id={id} setId={setId} postSuccess={postSuccess} />
                     </Portal>
                 )
             }

--- a/src/components/page/Personnel/AttendanceApproval/AttendanceApprovalModal/AttendanceApprovalModal.tsx
+++ b/src/components/page/Personnel/AttendanceApproval/AttendanceApprovalModal/AttendanceApprovalModal.tsx
@@ -9,23 +9,24 @@ import { AttendanceApproval } from "../../../../../api/api";
 import { IPostResponse } from "../../../../../models/interface/IPostResponse";
 import { IAttendanceDetail } from "../../../../../models/interface/personnel/attendance/IAttendanceDetail";
 import { postApi } from "../../../../../api/PersonnelApi/postApi";
+import { ILoginInfo } from "../../../../../models/interface/store/userInfo";
+import { loginInfoState } from "../../../../../stores/userInfo";
 
 interface AttendanceApprovalProps {
     id: number,
     setId: React.Dispatch<React.SetStateAction<number>>,
     postSuccess: () => void,
-    loginUserType: string,
-    loginUserEmpid: string
 }
 
 interface AttendanceApprovalDetailResponse {
     detail: IAttendanceDetail
 }
 
-export const AttendanceApprovalModal: FC<AttendanceApprovalProps> = ({ id, setId, postSuccess, loginUserType, loginUserEmpid }) => {
+export const AttendanceApprovalModal: FC<AttendanceApprovalProps> = ({ id, setId, postSuccess }) => {
     const [modal, setModal] = useRecoilState<Boolean>(modalState);
     const [attendanceApprovalDetail, setAttendanceApprovalDetail] = useState<IAttendanceDetail>();
     const formRef = useRef<HTMLFormElement>(null);
+    const [userInfo] = useRecoilState<ILoginInfo>(loginInfoState);
 
     useEffect(() => {
         id && searchDetail();
@@ -52,7 +53,7 @@ export const AttendanceApprovalModal: FC<AttendanceApprovalProps> = ({ id, setId
 
         const result = await postApi<IPostResponse>(AttendanceApproval.rejectAttendance, {
             reqId: id,
-            userIdx: loginUserEmpid,
+            userIdx: userInfo.empId,
             appReason: formData.get("appReason").toString()
         })
 
@@ -65,7 +66,7 @@ export const AttendanceApprovalModal: FC<AttendanceApprovalProps> = ({ id, setId
     const firstApproveAttendance = async () => {
         const result = await postApi<IPostResponse>(AttendanceApproval.firstApproveAttendance, {
             reqId: id,
-            userIdx: loginUserEmpid,
+            userIdx: userInfo.empId,
         })
 
         if (result.result === "success") {
@@ -84,7 +85,7 @@ export const AttendanceApprovalModal: FC<AttendanceApprovalProps> = ({ id, setId
         const result = await postApi<IPostResponse>(AttendanceApproval.approveRejectAttendance, {
             id: attAppId,
             reqId: id,
-            userIdx: loginUserEmpid,
+            userIdx: userInfo.empId,
             appReason: formData.get("appReason").toString()
         })
 
@@ -97,7 +98,7 @@ export const AttendanceApprovalModal: FC<AttendanceApprovalProps> = ({ id, setId
     const secondApproveAttendance = async () => {
         const result = await postApi<IPostResponse>(AttendanceApproval.secondApproveAttendance, {
             reqId: id,
-            userIdx: loginUserEmpid,
+            userIdx: userInfo.empId,
         })
 
         if (result.result === "success") {
@@ -160,20 +161,20 @@ export const AttendanceApprovalModal: FC<AttendanceApprovalProps> = ({ id, setId
                     </label>
                     <div className={"button-container"}>
                         {
-                            (loginUserType === "A" && (attendanceApprovalDetail?.reqStatus === "검토 대기"))
+                            (userInfo.userType === "A" && (attendanceApprovalDetail?.reqStatus === "검토 대기"))
                             && <button type='button' onClick={firstApproveAttendance}>승인</button>
                         }
                         {
-                            (loginUserType === "C" && (attendanceApprovalDetail?.reqStatus === "승인 대기"))
+                            (userInfo.userType === "C" && (attendanceApprovalDetail?.reqStatus === "승인 대기"))
                             && <button type='button' onClick={secondApproveAttendance}>승인</button>
                         }
                         {
-                            (loginUserType === "A" && ((attendanceApprovalDetail?.reqStatus === "검토 대기")))
+                            (userInfo.userType === "A" && ((attendanceApprovalDetail?.reqStatus === "검토 대기")))
                             && <button type='button' onClick={rejectAttendance}>반려</button>
                         }
                         {
-                            ((loginUserType === "A" && (attendanceApprovalDetail?.reqStatus === "승인 대기"))
-                                || (loginUserType === "C" && (attendanceApprovalDetail?.reqStatus === "승인 대기")))
+                            ((userInfo.userType === "A" && (attendanceApprovalDetail?.reqStatus === "승인 대기"))
+                                || (userInfo.userType === "C" && (attendanceApprovalDetail?.reqStatus === "승인 대기")))
                             && <button type='button' onClick={() => { approveRejectAttendance(attendanceApprovalDetail?.attAppId) }}>반려</button>
                         }
                         <button type='button' onClick={() => { setModal(!modal) }}>나가기</button>

--- a/src/components/page/Personnel/AttendanceApproval/AttendanceApprovalSearch/AttendanceApprovalSearch.tsx
+++ b/src/components/page/Personnel/AttendanceApproval/AttendanceApprovalSearch/AttendanceApprovalSearch.tsx
@@ -4,8 +4,11 @@ import { AttendanceContext } from "../../../../../api/Provider/AttendanceProvide
 import { StyledInput } from "../../../../common/StyledInput/StyledInput";
 import { StyledSelectBox } from "../../../../common/StyledSelectBox/StyledSelectBox";
 import { StyledButton } from "../../../../common/StyledButton/StyledButton";
+import { useRecoilState } from "recoil";
+import { loginInfoState } from "../../../../../stores/userInfo";
+import { ILoginInfo } from "../../../../../models/interface/store/userInfo";
 
-export const AttendanceApprovalSearch = ({ loginUserType }) => {
+export const AttendanceApprovalSearch = () => {
     const { setSearchKeyword } = useContext(AttendanceContext);
     const [startDate, setStartDate] = useState<string>();
     const [endDate, setEndDate] = useState<string>();
@@ -13,6 +16,7 @@ export const AttendanceApprovalSearch = ({ loginUserType }) => {
     const [name, setName] = useState<string>();
     const [selectReqStatusValue, setSelectReqStatusValue] = useState<string>("");
     const [isDefault, setIsDefault] = useState<boolean>(false);
+    const [userInfo] = useRecoilState<ILoginInfo>(loginInfoState);
 
     const optionsReqStatus = [
         { label: "전체", value: "" },
@@ -43,7 +47,7 @@ export const AttendanceApprovalSearch = ({ loginUserType }) => {
     }
 
     const setDefaultOptions = async () => {
-        switch (loginUserType) {
+        switch (userInfo.userType) {
             case "C":
                 setSelectReqStatusValue("승인 대기");
                 break;

--- a/src/pages/personnel/AttendanceApproval.tsx
+++ b/src/pages/personnel/AttendanceApproval.tsx
@@ -4,17 +4,13 @@ import { AttendanceApprovalMain } from "../../components/page/Personnel/Attendan
 import { AttendanceApprovalSearch } from "../../components/page/Personnel/AttendanceApproval/AttendanceApprovalSearch/AttendanceApprovalSearch";
 
 export const AttendanceApproval = () => {
-    const loginUserInfo = sessionStorage.getItem("userInfo");
-    const loginUserType = JSON.parse(loginUserInfo).userType;
-    const loginUserEmpid = JSON.parse(loginUserInfo).empId;
-
     return (
         <AttendanceProvider>
             <ContentBox variant='primary' fontSize='large'>
                 근태 조회 및 승인
             </ContentBox>
-            <AttendanceApprovalSearch loginUserType={loginUserType}></AttendanceApprovalSearch>
-            <AttendanceApprovalMain loginUserType={loginUserType} loginUserEmpid={loginUserEmpid}></AttendanceApprovalMain>
+            <AttendanceApprovalSearch></AttendanceApprovalSearch>
+            <AttendanceApprovalMain></AttendanceApprovalMain>
         </AttendanceProvider >
     );
 };


### PR DESCRIPTION
기존에는 sessionStorage와 props를 통해 컴포넌트끼리 userInfo 정보를 전달했으나, 
이로 인해 props drilling 문제가 발생함. 
불필요한 props 를 제거하고, userInfo 상태를 Recoil에서 직접 가져오도록 변경